### PR TITLE
CN-75 SyncPlugin should not use the fork manager if batch size is 1

### DIFF
--- a/src/Filesystem/MountManager/Plugin/SyncPlugin.php
+++ b/src/Filesystem/MountManager/Plugin/SyncPlugin.php
@@ -443,14 +443,14 @@ class SyncPlugin implements SyncPluginInterface
                     }
                 };
 
-                if ($forkManager) {
+                if ($forkManager && $batchSize != 1) {
                     $forkManager->addWorker($executor);
                 } else {
                     $executor();
                 }
             }
 
-            if ($forkManager) {
+            if ($forkManager && $batchSize != 1) {
                 try {
                     $forkManager->execute();
                 } catch (\Exception $e) {


### PR DESCRIPTION
SyncPlugin should not use the fork manager if batch size is 1